### PR TITLE
add two audio channel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # scripts
 A collection of scripts that I use.
 
-Working on documentation...
+# Recover Deleted Files on Linux
+
+You should have the `testdisk` command downloaded via the `setup/run_me.sh` script.
+If not, download via `sudo apt install testdisk`. Follow the documentation here:
+
+https://adamtheautomator.com/linux-recover-deleted-files/
 
 # Stack
 perl v5.26.1 (x86_64-linux-gnu-thread-multi)

--- a/dot_files/.bashrc
+++ b/dot_files/.bashrc
@@ -136,6 +136,7 @@ MI()
     local audio=$(mediainfo --InForm="Audio;%Format%" "${file}")
     local width=$(mediainfo --InForm="Video;%Width%" "${file}")
     local height=$(mediainfo --InForm="Video;%Height%" "${file}")
+    local channels=$(mediainfo --InForm="Audio;%Channel(s)%" "${file}")
 
     echo "Resolution : $width X $height"
 
@@ -147,5 +148,6 @@ MI()
     fi
 
     echo "Audio Codec: $audio"
+    echo "Audio Channels: $channels"
 }
 

--- a/setup/run_me.sh
+++ b/setup/run_me.sh
@@ -21,6 +21,7 @@ sudo apt install -y \
     python3-pip \
     ncdu \
     mediainfo \
+    testdisk \
     renameutils # qmv command
 
 


### PR DESCRIPTION
* Add `-ac 2` flag to ruby convert script.
* The convert script will automatically convert the audio codec if the audio channels if greater than 2 **OR** if the audio codec is not `AAC`.
* Add number of audio channel output to `MI()` bash function.
* Updated readme on root page showing how to recover a deleted file on linux.
* Added the `testdisk` program to the `setup/run_me.sh` file.